### PR TITLE
Add missing 'attrs' package to project dependencies.

### DIFF
--- a/changelog.d/9.fixing.md
+++ b/changelog.d/9.fixing.md
@@ -1,0 +1,1 @@
+Add missing 'attrs' package to project dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dynamic = [
   "version",
 ]
 dependencies = [
+  "attrs",
   "jinja2>=2.7.2",
   "pluggy",
   "PyYAML",
@@ -94,7 +95,6 @@ python = "3.11"
 
 [tool.hatch.envs.lint]
 dependencies = [
-    "attrs", # needed for type-checking tests
     "black",
     "ruff",
     "mypy",
@@ -122,7 +122,6 @@ lint-action = [
 
 [tool.hatch.envs.ci]
 dependencies = [
-    "attrs",
     "coverage[toml]",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This was overlooked since it was in the dependencies for the 'lint' and 'ci' environments.

Closes #9.