### PR TITLE
Install 'extensions' hook for plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist
 build
 src/jinjanator/version.py
+__pycache__

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features:
 * Jinja2 templating
 * INI, YAML, JSON data sources supported
 * Environment variables can be used with or without data files
-* Plugins can provide additional formats, filters, tests, and global
+* Plugins can provide additional formats, filters, tests, extensions and global
   functions (see
   [jinjanator-plugins](https://github.com/kpfleming/jinjanator-plugins)
   for details)

--- a/changelog.d/29.adding.md
+++ b/changelog.d/29.adding.md
@@ -1,0 +1,1 @@
+Support for 'extensions' plugins which enable Jinja2 extensions (contributed by @llange)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = [
 dependencies = [
   "attrs",
   "jinja2>=2.7.2",
-  "jinjanator-plugins==23.4.*",
+  "jinjanator-plugins==24.1.*",
   "PyYAML",
   "typing-extensions",
 ]

--- a/src/jinjanator/cli.py
+++ b/src/jinjanator/cli.py
@@ -84,6 +84,10 @@ class Jinja2TemplateRenderer:
         for plugin_tests in plugin_hook_callers.plugin_tests():
             self._env.tests.update(plugin_tests)
 
+        for plugin_extensions in plugin_hook_callers.plugin_extensions():
+            for extension in plugin_extensions:
+                self._env.add_extension(extension)
+
     def render(self, template_name: str, context: Mapping[str, str]) -> str:
         return self._env.get_template(template_name).render(context)
 

--- a/tests/test_plugin/jinjanator_test_plugin.py
+++ b/tests/test_plugin/jinjanator_test_plugin.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Iterable, Mapping
 
 from jinjanator_plugins import (
+    Extensions,
     Filters,
     FormatOptionUnsupportedError,
     FormatOptionValueError,
@@ -10,6 +11,7 @@ from jinjanator_plugins import (
     Globals,
     Identity,
     Tests,
+    plugin_extensions_hook,
     plugin_filters_hook,
     plugin_formats_hook,
     plugin_globals_hook,
@@ -73,3 +75,8 @@ def plugin_formats() -> Formats:
 @plugin_globals_hook
 def plugin_globals() -> Globals:
     return {"null": null_filter}
+
+
+@plugin_extensions_hook
+def plugin_extensions() -> Extensions:
+    return ["jinja2.ext.do"]


### PR DESCRIPTION
Support for a new hook that allows to add new [Jinja2 extensions](https://jinja.palletsprojects.com/en/3.1.x/extensions/) in the Environment.