### PR TITLE
Add a 'j2' CLI entrypoint, for users switching from 'j2cli'.

### DIFF
--- a/changelog.d/25.adding.md
+++ b/changelog.d/25.adding.md
@@ -1,0 +1,1 @@
+Added 'j2' CLI entrypoint, for users converting from 'j2cli'.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
 ]
 urls."Bug Tracker" = "https://github.com/kpfleming/jinjanator/issues"
 urls."Homepage" = "https://github.com/kpfleming/jinjanator"
+scripts.j2 = "jinjanator.cli:main"
+
 scripts.jinjanate = "jinjanator.cli:main"
 
 [tool.hatch.version]


### PR DESCRIPTION
Closes issue #25.