### PR TITLE
Added python-dotenv so native interpolation works

### DIFF
--- a/changelog.d/36.adding.md
+++ b/changelog.d/36.adding.md
@@ -1,0 +1,1 @@
+Support for full 'interpolation' in env-format input files (contributed by @lgtml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "attrs",
   "jinja2>=2.7.2",
   "jinjanator-plugins==24.1.*",
+  "python-dotenv>=1",
   "pyyaml",
   "typing-extensions",
 ]

--- a/src/jinjanator/formats.py
+++ b/src/jinjanator/formats.py
@@ -4,10 +4,12 @@ import configparser
 import json
 import keyword
 
+from io import StringIO
 from typing import Any, Iterable, Mapping
 
 import yaml
 
+from dotenv import dotenv_values
 from jinjanator_plugins import (
     FormatOptionUnsupportedError,
     FormatOptionValueError,
@@ -248,12 +250,10 @@ class EnvFormat:
         $ j2 config.j2 - < data.env
         """
 
-        return dict(
-            filter(
-                lambda line: len(line) == 2,  # noqa: PLR2004
-                (list(map(str.strip, line.split("=", 1))) for line in data_string.split("\n")),
-            ),
-        )
+        data = StringIO(data_string)
+        results_dict = dotenv_values(stream=data)
+
+        return {k: v if v is not None else "" for (k, v) in results_dict.items()}
 
 
 @plugin_formats_hook

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -27,12 +27,20 @@ def test_import(make_file_pair: FilePairFactory) -> None:
 
 
 def test_equals_sign_in_file_value(make_file_pair: FilePairFactory) -> None:
+    # A: key with out an equals sign should return an empty string.
+    #  Slight drift from python-dotenv to maintain current plugin definition
+    # B: C should return their assigned values
+    # D: key with an equals sign and no value should return empty string
+    # E: should interpolate the value of C
+    # F: should fail to interpolate the value of G due to order
+    # G: should be assigned value
+    # Ref: https://pypi.org/project/python-dotenv/
     files = make_file_pair(
-        "{{ A|default() }}/{{ B }}/{{ C }}",
-        "A\nB=1\nC=val=1\n",
+        "{{ A|default() }}/{{ B }}/{{ C }}/{{ D }}/{{ E }}/{{ F }}/{{ G }}",
+        "A\nB=1\nC=val=1\nD=\nE=${C}\nF=${G}\nG=1",
         "env",
     )
-    assert "/1/val=1" == render_file(files, [])
+    assert "/1/val=1//val=1//1" == render_file(files, [])
 
 
 def test_filter(make_file_pair: FilePairFactory, monkeypatch: Any) -> None:


### PR DESCRIPTION
Thanks for Jinjanator super handy!

I wanted to suggest using the python-dotenv module so that it can match the documented interpolation and behavior. I ran into issues when I was expecting one behavior and got the other.

example.
```dotenv
CLOUD_REGION=ca-central-1
CLOUD_RESOURCE=meow
CLOUD_URL=${CLOUD_RESOURCE}-${CLOUD_REGION}.cloud.cloud
```